### PR TITLE
Add section "Problems" to README and hint the way to solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Feel free to clone https://github.com/literarymachine/skos.git to poke around. G
 ## Use start scripts and monit
 You may want to use the start scripts in `scripts/` to manage via init and to monitor with `monit`.
 
+## Problems
+Depending on special circumstances you may get errors in the log files, e.g.
+`EMFILE: too many open files`. [Search our issues for solutions](https://github.com/skohub-io/skohub-vocabs/issues?q=is%3Aissue) or feel encouraged to open a new issue if you can't find a solution.
+
 ## Credits
 
 The project to create a stable beta version of SkoHub has been funded by the North-Rhine Westphalian Library Service Centre (hbz) and carried out in cooperation with [graphthinking GmbH](https://graphthinking.com/) in 2019/2020.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Running `npm run listen` will start the server on the defined `PORT` and expose 
 Feel free to clone https://github.com/literarymachine/skos.git to poke around. Go to https://github.com/YOUR_GITHUB_USER/skos/settings/hooks/new to set up the web hook (get in touch to receive the secret). Edit https://github.com/YOUR_GITHUB_USER/skos/edit/master/hochschulfaecher.ttl and commit the changes to master. This will trigger a build and expose it at https://test.skohub.io/YOUR_GITHUB_USER/skos/w3id.org/class/hochschulfaecher/scheme.
 
 ## Use start scripts and monit
+
 You may want to use the start scripts in `scripts/` to manage via init and to monitor with `monit`.
 
-## Problems
+## Troubleshooting
+
 Depending on special circumstances you may get errors in the log files, e.g.
 `EMFILE: too many open files`. [Search our issues for solutions](https://github.com/skohub-io/skohub-vocabs/issues?q=is%3Aissue) or feel encouraged to open a new issue if you can't find a solution.
 


### PR DESCRIPTION
This is a rather generic note how to cope with problems, but as we already
have a good database of problems and solutions why not pointing explicitly
to it.

Implements https://github.com/skohub-io/skohub-vocabs/issues/112.