### PR TITLE
164 umlaute

### DIFF
--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -26,6 +26,12 @@ const App = ({pageContext, children}) => {
       .then(response => response.json())
       .then(serialized => {
         const idx = FlexSearch.create()
+        // add custom matcher to match umlaute at beginning of string
+        idx.addMatcher({
+          'ä': 'a', // replaces all 'ä' to 'a'
+          'ö': 'o',
+          'ü': 'u'
+        });
         idx.import(serialized)
         setIndex(idx)
         console.log("index loaded", idx.info())


### PR DESCRIPTION
It seems like flexsearch does not index umlaute. The work around seems to be to add a custom matcher, that converts, e.g. "ä" to "a" (https://github.com/nextapps-de/flexsearch/tree/0.6.32#add-custom-matcher).

This has the effect that words with "a" get also shown, but at least no empty list is shown.

Don't know if this is the smartest solution, but I guess it's an improvement.

might close #164