### PR TITLE
add compression options to .htaccess

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -121,17 +121,6 @@ exports.onPreBootstrap = async ({createContentDigest, actions}) => {
 
 exports.sourceNodes = async ({ actions }) => {
   const { createTypes } = actions
-  const htaccess = [
-    'DirectoryIndex index',
-    'AddType text/index .index',
-    'AddType application/json .json',
-    'AddType application/ld+json .jsonld',
-    'AddType application/activity+json .jsonas'
-  ]
-  await createData({
-    path: '/.htaccess',
-    data: htaccess.join("\n")
-  })
   createTypes(types(languages))
 }
 
@@ -224,6 +213,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
       path: getFilePath(conceptScheme.id, 'jsonld'),
       data: JSON.stringify(omitEmpty(Object.assign({}, conceptScheme, context.jsonld), null, 2))
     })
+    // create index files
     languages.forEach(language => createData({
       path: getFilePath(conceptScheme.id, `${language}.index`),
       data: JSON.stringify(indexes[language].export(), null, 2)

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,0 +1,33 @@
+DirectoryIndex index
+AddType text/index .index
+AddType application/json .json
+AddType application/ld+json .jsonld
+AddType application/activity+json .jsonas
+
+<IfModule mod_deflate.c>
+  # Compress HTML, CSS, JavaScript, Text, XML and fonts
+  AddOutputFilterByType DEFLATE application/javascript
+  AddOutputFilterByType DEFLATE application/rss+xml
+  AddOutputFilterByType DEFLATE application/vnd.ms-fontobject
+  AddOutputFilterByType DEFLATE application/x-font
+  AddOutputFilterByType DEFLATE application/x-font-opentype
+  AddOutputFilterByType DEFLATE application/x-font-otf
+  AddOutputFilterByType DEFLATE application/x-font-truetype
+  AddOutputFilterByType DEFLATE application/x-font-ttf
+  AddOutputFilterByType DEFLATE application/x-javascript
+  AddOutputFilterByType DEFLATE application/xhtml+xml
+  AddOutputFilterByType DEFLATE application/xml
+  AddOutputFilterByType DEFLATE font/opentype
+  AddOutputFilterByType DEFLATE font/otf
+  AddOutputFilterByType DEFLATE font/ttf
+  AddOutputFilterByType DEFLATE image/svg+xml
+  AddOutputFilterByType DEFLATE image/x-icon
+  AddOutputFilterByType DEFLATE text/css
+  AddOutputFilterByType DEFLATE text/html
+  AddOutputFilterByType DEFLATE text/javascript
+  AddOutputFilterByType DEFLATE text/plain
+  AddOutputFilterByType DEFLATE text/xml
+
+  AddOutputFilterByType DEFLATE text/index
+
+</IfModule>


### PR DESCRIPTION
I added compression via `.htaccess`. 

I had not that big vocab that @acka47 to test,but used some other vocab, that has a quite big index of around 23.6MB. With compression enabled I was able to reduce transferred size to 2.55MB. You can check out here: http://c102-077.cloud.gwdg.de/w3id.org/openeduhub/vocabs/oeh-topics/5e40e372-735c-4b17-bbf7-e827a5702b57.de.html

This might finally close #153. 

Though using this approach, we should add a note in the README that we recommend using apache web server. I think we are implicitly already doing that using Multiviews and `.htaccess`. If testing on dev is ok, I will add something in the README