### PR TITLE
Support for skos:collection

### DIFF
--- a/src/components/Collection.js
+++ b/src/components/Collection.js
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/react'
+import { Link } from 'gatsby'
+import { i18n, getFilePath } from '../common'
+import JsonLink from './JsonLink'
+
+const Collection = ({ pageContext: { node: collection, language, baseURL } }) => (
+  <div className="content block">
+    <h1>{i18n(language)(collection.prefLabel)}</h1>
+    <h2>{collection.id}</h2>
+    <JsonLink to={baseURL + getFilePath(collection.id, "json")} />
+      <ul>
+        {
+          collection.member.map((member) => (
+            <li>
+              <Link to={getFilePath(member.id, `${language}.html`)}>
+                {i18n(language)(member.prefLabel)}
+              </Link>
+            </li>
+          ))
+        }
+        </ul>
+  </div>
+)
+
+export default Collection

--- a/src/components/Collection.js
+++ b/src/components/Collection.js
@@ -12,7 +12,7 @@ const Collection = ({ pageContext: { node: collection, language, baseURL } }) =>
       <ul>
         {
           collection.member.map((member) => (
-            <li>
+            <li key={member.id}>
               <Link to={getFilePath(member.id, `${language}.html`)}>
                 {i18n(language)(member.prefLabel)}
               </Link>

--- a/src/components/Concept.js
+++ b/src/components/Concept.js
@@ -140,7 +140,7 @@ const Concept = ({ pageContext: { node: concept, language, collections, baseURL 
         </ul>
       </div>
     )}
-      {collections.length > 0 && (
+      {collections && collections.length > 0 && (
         <div className="collections">
             <h3>in Collections</h3>
             <ul>

--- a/src/components/Concept.js
+++ b/src/components/Concept.js
@@ -6,7 +6,7 @@ import JsonLink from './JsonLink'
 
 import { i18n, getDomId, getFilePath } from '../common'
 
-const Concept = ({ pageContext: { node: concept, language, baseURL } }) => (
+const Concept = ({ pageContext: { node: concept, language, collections, baseURL } }) => (
   <div className="content block" id={getDomId(concept.id)}>
     <h1>
       {concept.notation &&
@@ -140,6 +140,20 @@ const Concept = ({ pageContext: { node: concept, language, baseURL } }) => (
         </ul>
       </div>
     )}
+      {collections.length > 0 && (
+        <div className="collections">
+            <h3>in Collections</h3>
+            <ul>
+                {collections.map((collection) => (
+                  <li key={collection.id}>
+                      <Link to={getFilePath(collection.id, `${language}.html`)}>
+                          {i18n(language)(collection.prefLabel)}
+                      </Link>
+                  </li>
+                ))}
+            </ul>
+        </div>
+      )}
   </div>
 )
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,3 +1,25 @@
+module.exports.allCollection = (languages) => `
+{
+  allCollection {
+    edges {
+      node {
+        id
+        type
+        prefLabel {
+            ${[...languages].join(' ')}
+        }
+        member {
+          id
+          prefLabel {
+            ${[...languages].join(' ')}
+          }
+        }
+      }
+    }
+  }
+}
+`
+
 module.exports.allConcept = (inScheme, languages) => `
   {
     allConcept(

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -13,7 +13,7 @@ import SEO from '../components/seo'
 import { style } from '../styles/concepts.css.js'
 
 const App = ({pageContext, children}) => {
-  const conceptSchemeId = pageContext.node.type === 'ConceptScheme'
+  const conceptSchemeId = (pageContext.node.type === 'ConceptScheme' || pageContext.node.type === 'Collection')
     ? pageContext.node.id
     : pageContext.node.inScheme.id
   const [index, setIndex] = useState(FlexSearch.create())
@@ -28,7 +28,7 @@ const App = ({pageContext, children}) => {
         const idx = FlexSearch.create()
         // add custom matcher to match umlaute at beginning of string
         idx.addMatcher({
-          '[Aä]': "a", // replaces all 'ä' to 'a'
+          '[Ää]': "a", // replaces all 'ä' to 'a'
           '[Öö]': "o",
           '[Üü]': "u",
         })

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,11 @@
 module.exports = (languages) => `
+
+  type Collection implements Node {
+    type: String,
+    prefLabel: LanguageMap,
+    member: [Concept] @link(from: "member___NODE")
+  }
+
   type ConceptScheme implements Node {
     type: String,
     title: LanguageMap,


### PR DESCRIPTION
This pull request adds support for `skos:collection` as described in https://github.com/skohub-io/skohub-vocabs/issues/159#issuecomment-1293141778

**_Link from concept to collection:_**
<img width="1409" alt="Bildschirmfoto 2022-10-27 um 18 19 37" src="https://user-images.githubusercontent.com/19183925/198345215-a9745b6d-8386-4af3-9bec-de31b01e7d02.png">

**_Collection page linking to all contained concepts:_**
<img width="1417" alt="Bildschirmfoto 2022-10-27 um 18 19 46" src="https://user-images.githubusercontent.com/19183925/198345267-bbc72123-2c85-4329-b6ee-6b3baeb9eb17.png">


Since SKOS does not provide an inverse for the `skos:member` relation, collection membership of concepts is determined and stored manually during page creation.

Fixes #159 