### PR TITLE
Hide tree controls for flat lists

### DIFF
--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -20,6 +20,17 @@ const App = ({pageContext, children}) => {
   const [query, setQuery] = useState(null)
   const [tree, setTree] = useState(pageContext.node.type === 'ConceptScheme' ? pageContext.node : null)
 
+  let showTreeControls = false;
+
+  if (!showTreeControls && tree && tree.hasTopConcept) {
+    for (const topConcept of tree.hasTopConcept) {
+      if (topConcept.narrower) {
+        showTreeControls = true;
+        break;
+      }
+    }
+  }
+
   // Fetch and load the serialized index
   useEffect(() => {
     fetch(pageContext.baseURL + getFilePath(conceptSchemeId, `${pageContext.language}.index`))
@@ -70,7 +81,9 @@ const App = ({pageContext, children}) => {
             placeholder="Search"
             autoFocus
           />
-          <TreeControls/>
+          {showTreeControls && (
+            <TreeControls/>
+          )}
           {tree && (
             <NestedList
               items={tree.hasTopConcept}


### PR DESCRIPTION
Hides tree control buttons for flat lists by checking whether any top concept of a scheme has narrower concepts defined or not and thereby fixes #148. The implementation is a simple "vanilla" JavaScript solution.

![Bildschirmfoto 2022-11-29 um 18 02 18](https://user-images.githubusercontent.com/19183925/204594468-1c742658-bcf2-42ca-80dd-f33e7faf333e.png)
