### PR TITLE
Add documentation on how to add additional properties #274

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,44 @@ After that you have to adjust the config with the appropriate settings for `font
 You need to provide all settings for `regular` as well as `bold`.
 Otherwise SkoHub Vocabs will use the default fonts.
 
+## Adding additional properties to SkoHub Vocabs
+
+If you need additional properties beside SKOS, here is how you add them:
+
+E.g. add `https://schema.org/url`
+
+* [`context.js`](./src/context.js), add the property you want to add:
+
+```json
+url: {
+  "@id": "schema:url",
+  "@container": "@set"
+}
+```
+
+* [`queries.js`](./src/queries.js), add the property:
+
+```graphql
+...
+topConceptOf {
+    id
+    title {
+      ${[...languages].join(" ")}
+    }
+  }
+url
+...
+```
+
+* (Only necessary if you want to interact with that attribute on the built pages. E.g. for displaying it on concept pages) [`types.js`](./src/types.js), add the GraphQL type:
+
+```graphql
+url: [String]
+```
+
+This will add the `url` field, being an array of strings.
+For other types, compare with already existing properties and just copy as you need.
+
 ## Troubleshooting
 
 Depending on special circumstances you may get errors in the log files, e.g.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Otherwise SkoHub Vocabs will use the default fonts.
 
 If you need additional properties beside SKOS, here is how you add them:
 
-E.g. add `https://schema.org/url`
+E.g. add `https://schema.org/url` with a value of type string (see below if it is a resource / URI)
 
 * [`context.js`](./src/context.js), add the property you want to add:
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ url
 ...
 ```
 
+If the property you are adding is a resource (i.e. has a URI), you need to specify that you want its `id`:
+
+```graphql
+...
+topConceptOf {
+    id
+    title {
+      ${[...languages].join(" ")}
+    }
+  }
+url {
+  id
+}
+...
+```
+
 * (Only necessary if you want to interact with that attribute on the built pages. E.g. for displaying it on concept pages) [`types.js`](./src/types.js), add the GraphQL type:
 
 ```graphql

--- a/src/context.js
+++ b/src/context.js
@@ -6,7 +6,7 @@ const jsonld = {
     "@vocab": "http://www.w3.org/2004/02/skos/core#",
     xsd: "http://www.w3.org/2001/XMLSchema#",
     dct: "http://purl.org/dc/terms/",
-    schema: "http://schema.org/",
+    schema: "https://schema.org/",
     vann: "http://purl.org/vocab/vann/",
     ldp: "http://www.w3.org/ns/ldp#",
     title: {


### PR DESCRIPTION
Besides I noticed that the URI of schema.org in context.js is not `https`. It works since schema.org seems to redirect, but in their own documentation the always use `https` see: https://schema.org/isBasedOn

@lummerland do you want to try out if this works for your use case?
@acka47 you might also want to have a look at this. 