### PR TITLE
Hide @none language tag from UI (#335)

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -65,24 +65,21 @@ const getDomId = (url) => {
  */
 const parseLanguages = (graph) => {
   const languages = new Set()
+  // JSON-LD's @container: "@language" places untagged literals under the
+  // "@none" key. That isn't a language and must not appear in the UI (#335).
+  const addFrom = (langMap) => {
+    Object.keys(langMap).forEach(
+      (l) => l !== "@none" && langMap[l] && languages.add(l)
+    )
+  }
   const parse = (arrayOfObj) => {
     for (let obj of arrayOfObj) {
       // Concept Schemes
-      obj?.title &&
-        Object.keys(obj.title).forEach((l) => obj.title[l] && languages.add(l))
+      obj?.title && addFrom(obj.title)
       // Concepts
-      obj?.prefLabel &&
-        Object.keys(obj.prefLabel).forEach(
-          (l) => obj.prefLabel[l] && languages.add(l)
-        )
-      obj?.altLabel &&
-        Object.keys(obj.altLabel).forEach(
-          (l) => obj.altLabel[l] && languages.add(l)
-        )
-      obj?.hiddenLabel &&
-        Object.keys(obj.hiddenLabel).forEach(
-          (l) => obj.hiddenLabel[l] && languages.add(l)
-        )
+      obj?.prefLabel && addFrom(obj.prefLabel)
+      obj?.altLabel && addFrom(obj.altLabel)
+      obj?.hiddenLabel && addFrom(obj.hiddenLabel)
       obj?.hasTopConcept && parse(obj.hasTopConcept)
       obj?.narrower && parse(obj.narrower)
     }

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -10,4 +10,25 @@ describe("gatsby node", () => {
     const languages = parseLanguages(compactedHashURI["@graph"])
     expect(languages.size).toBe(2)
   })
+  it("ignores the JSON-LD '@none' key when collecting languages (#335)", () => {
+    const graph = [
+      {
+        type: "ConceptScheme",
+        title: { en: "Vocab", "@none": "Untagged title" },
+        hasTopConcept: [
+          {
+            type: "Concept",
+            prefLabel: { de: "Begriff", "@none": "Untagged label" },
+            altLabel: { "@none": "Other untagged" },
+            hiddenLabel: { "@none": "Hidden untagged" },
+          },
+        ],
+      },
+    ]
+    const languages = parseLanguages(graph)
+    expect(languages.has("@none")).toBe(false)
+    expect(languages.has("en")).toBe(true)
+    expect(languages.has("de")).toBe(true)
+    expect(languages.size).toBe(2)
+  })
 })


### PR DESCRIPTION
Closes #335.

## Summary
- `parseLanguages` (`src/common.js`) was treating JSON-LD's `@none` bucket — where the JSON-LD compactor stashes untagged literals — as a real language code, so it ended up in `fields.languages` and rendered as a selectable button in the header language switcher.
- Filter `@none` out at the source so every downstream consumer (header, index page, `getUserLang`, language-aware queries) sees only real language codes.
- The on-disk JSON-LD output is unaffected; `@none`-keyed values stay in the data, they're just not exposed as a switchable language.
