### PR TITLE
Sort concept entries by label or notation (closes #336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ You can configure the following settings:
     - Colors
     - Fonts
 - Searchable Fields
+- Sort order
 
 The settings are explained in the following sections.
 
@@ -165,6 +166,26 @@ Then provide `http://my-awesome-domain.org` as `custom_domain` in your `config.y
 ### Fail on Validation
 
 If `true` (default) the build process will stop if a validation error occures.
+
+### Sort order
+
+Concept entries inside a ConceptScheme tree (and members of a `skos:Collection`)
+can be sorted at display time. Set the initial default in `config.yaml`:
+
+```yaml
+sortBy: "prefLabel"   # one of: "prefLabel" | "notation" | "none"
+```
+
+- `"prefLabel"` (default) — alphabetical by `skos:prefLabel` in the currently
+  selected language. Locale-aware via `Intl.Collator` and numerically aware
+  (so `Item 2` comes before `Item 10`).
+- `"notation"` — sorted by `skos:notation`. Numeric and dotted numeric
+  notations sort naturally (`1.1`, `1.2`, `1.10`). Items without a notation
+  fall to the bottom and are tie-broken by `prefLabel`.
+- `"none"` — preserves the order in which entries appear in the source TTL.
+
+Visitors can switch between these options at runtime via the **Sort** selector
+that lives next to the Collapse / Expand controls in the tree sidebar.
 
 ### UI
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -3,6 +3,7 @@
 tokenizer: "full" # strict, forward, reverse, full
 custom_domain: ""
 fail_on_validation: true
+sortBy: "prefLabel" # one of: "prefLabel" | "notation" | "none" — initial default for the tree/collection sort selector
 searchableAttributes:
   - "prefLabel" # you should not delete this one
   - "notation"

--- a/cypress/e2e/sort.cy.js
+++ b/cypress/e2e/sort.cy.js
@@ -1,0 +1,57 @@
+describe("Sort entries", () => {
+  // Top concepts from systematik.ttl, in source (TTL) order:
+  //   n1 Geisteswissenschaften, n2 Sport, n3 Rechts-..., n4 Mathematik,
+  //   n5 Humanmedizin, n7 Agrar-..., n8 Ingenieurwissenschaften, n9 Kunst
+  // Notations: 1, 2, 3, 4, 5, 7, 8, 9
+  // Alphabetical (de): Agrar-, Geisteswissenschaften, Humanmedizin,
+  //   Ingenieurwissenschaften, Kunst, Mathematik, Rechts-, Sport
+  const url = "/w3id.org/kim/hochschulfaechersystematik/scheme.html?lang=de"
+
+  it("renders the sort selector with prefLabel as default", () => {
+    cy.visit(url)
+    cy.findByRole("combobox", { name: /sort entries by/i })
+      .should("exist")
+      .and("have.value", "prefLabel")
+  })
+
+  it("default order is alphabetical by prefLabel", () => {
+    cy.visit(url)
+    // First top-level link in the tree should start with "Agrar"
+    cy.get(".concepts > nav, .concepts").should("exist")
+    cy.get(".concepts ul li > div > a")
+      .first()
+      .invoke("text")
+      .should("match", /Agrar/)
+  })
+
+  it("switching to Notation reorders the tree by notation", () => {
+    cy.visit(url)
+    cy.findByRole("combobox", { name: /sort entries by/i }).select("notation")
+    // Notation 1 → Geisteswissenschaften
+    cy.get(".concepts ul li > div > a")
+      .first()
+      .invoke("text")
+      .should("match", /Geisteswissenschaften/)
+  })
+
+  it("switching to Source order preserves TTL order", () => {
+    cy.visit(url)
+    cy.findByRole("combobox", { name: /sort entries by/i }).select("none")
+    cy.get(".concepts ul li > div > a")
+      .first()
+      .invoke("text")
+      .should("match", /Geisteswissenschaften/)
+  })
+
+  it("sort selector is visible even on flat schemes (no hierarchy)", () => {
+    cy.visit("/purl.org/dcx/lrmi-vocabs/interactivityType/index.html", {
+      onBeforeLoad(win) {
+        Object.defineProperty(win.navigator, "language", { value: "en-EN" })
+      },
+    })
+    cy.findByRole("combobox", { name: /sort entries by/i }).should("exist")
+    // Collapse/Expand should still be hidden on flat schemes
+    cy.contains("Collapse").should("not.exist")
+    cy.contains("Expand").should("not.exist")
+  })
+})

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,6 +16,7 @@ module.exports = {
     searchableAttributes: config.searchableAttributes,
     customDomain: config.customDomain,
     failOnValidation: config.failOnValidation,
+    sortBy: config.sortBy,
   },
   pathPrefix: `${process.env.BASEURL || ""}`,
   plugins: [

--- a/src/common.js
+++ b/src/common.js
@@ -144,6 +144,7 @@ function loadConfig(configFile, defaultFile) {
       userConfig.searchableAttributes || defaults.searchableAttributes,
     customDomain: userConfig.custom_domain || "",
     failOnValidation: userConfig.fail_on_validation,
+    sortBy: userConfig.sortBy || defaults.sortBy || "prefLabel",
   }
 
   // check if all relevant colors are contained, otherwise use default colors

--- a/src/components/Collection.jsx
+++ b/src/components/Collection.jsx
@@ -2,10 +2,13 @@ import { Link } from "gatsby"
 import { i18n, getFilePath } from "../common"
 import JsonLink from "./JsonLink"
 import { useSkoHubContext } from "../context/Context"
+import { getConfigAndConceptSchemes } from "../hooks/configAndConceptSchemes"
+import { sortConcepts } from "../sortConcepts"
 import { useEffect, useState } from "react"
 
 const Collection = ({ pageContext: { node: collection, customDomain } }) => {
   const { data } = useSkoHubContext()
+  const { config } = getConfigAndConceptSchemes()
   const [language, setLanguage] = useState("")
 
   useEffect(() => {
@@ -14,13 +17,16 @@ const Collection = ({ pageContext: { node: collection, customDomain } }) => {
     }
   }, [data?.selectedLanguage])
 
+  const sortBy = data?.sortBy ?? config?.sortBy ?? "prefLabel"
+  const sortedMembers = sortConcepts(collection.member, sortBy, language)
+
   return (
     <div>
       <h1>{i18n(language)(collection.prefLabel)}</h1>
       <h2>{collection.id}</h2>
       <JsonLink to={getFilePath(collection.id, "json", customDomain)} />
       <ul>
-        {collection.member.map((member) => (
+        {sortedMembers.map((member) => (
           <li key={member.id}>
             <Link to={getFilePath(member.id, `html`, customDomain)}>
               {i18n(language)(member.prefLabel) ||

--- a/src/components/TreeControls.jsx
+++ b/src/components/TreeControls.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import React, { useEffect } from "react"
 import { css } from "@emotion/react"
 import { getConfigAndConceptSchemes } from "../hooks/configAndConceptSchemes"
 import { useSkoHubContext } from "../context/Context"

--- a/src/components/TreeControls.jsx
+++ b/src/components/TreeControls.jsx
@@ -1,44 +1,89 @@
+import { useEffect } from "react"
 import { css } from "@emotion/react"
+import { getConfigAndConceptSchemes } from "../hooks/configAndConceptSchemes"
+import { useSkoHubContext } from "../context/Context"
 
 const style = css`
   display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   margin-bottom: 10px;
+  align-items: center;
 
   input[type="button"] {
     flex: 1;
     padding: 5px 10px;
+    min-width: 80px;
+  }
 
-    &:first-of-type {
-      margin-right: 10px;
+  .sortControl {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+    font-size: 0.9em;
+
+    select {
+      padding: 4px 6px;
     }
   }
 `
 
-const TreeControls = () => (
-  <div className="TreeControls" css={style}>
-    <input
-      type="button"
-      className="inputStyle"
-      value="Collapse"
-      onClick={() => {
-        ;[...document.querySelectorAll(".treeItemIcon")].forEach((el) => {
-          el.classList.add("collapsed")
-          el.setAttribute("aria-expanded", false)
-        })
-      }}
-    />
-    <input
-      type="button"
-      className="inputStyle"
-      value="Expand"
-      onClick={() => {
-        ;[...document.querySelectorAll(".collapsed")].forEach((el) => {
-          el.classList.remove("collapsed")
-          el.setAttribute("aria-expanded", true)
-        })
-      }}
-    />
-  </div>
-)
+const TreeControls = ({ hasNesting = true }) => {
+  const { config } = getConfigAndConceptSchemes()
+  const { data, updateState } = useSkoHubContext()
+
+  // Initialise sortBy from config on first render if it hasn't been set yet.
+  useEffect(() => {
+    if (data.sortBy == null) {
+      updateState({ ...data, sortBy: config?.sortBy || "prefLabel" })
+    }
+  }, [data.sortBy, config?.sortBy])
+
+  const currentSort = data.sortBy ?? config?.sortBy ?? "prefLabel"
+
+  return (
+    <div className="TreeControls" css={style}>
+      {hasNesting && (
+        <>
+          <input
+            type="button"
+            className="inputStyle"
+            value="Collapse"
+            onClick={() => {
+              ;[...document.querySelectorAll(".treeItemIcon")].forEach((el) => {
+                el.classList.add("collapsed")
+                el.setAttribute("aria-expanded", false)
+              })
+            }}
+          />
+          <input
+            type="button"
+            className="inputStyle"
+            value="Expand"
+            onClick={() => {
+              ;[...document.querySelectorAll(".collapsed")].forEach((el) => {
+                el.classList.remove("collapsed")
+                el.setAttribute("aria-expanded", true)
+              })
+            }}
+          />
+        </>
+      )}
+      <label className="sortControl">
+        Sort:
+        <select
+          aria-label="Sort entries by"
+          value={currentSort}
+          onChange={(e) => updateState({ ...data, sortBy: e.target.value })}
+        >
+          <option value="prefLabel">Label</option>
+          <option value="notation">Notation</option>
+          <option value="none">Source order</option>
+        </select>
+      </label>
+    </div>
+  )
+}
 
 export default TreeControls

--- a/src/components/TreeControls.jsx
+++ b/src/components/TreeControls.jsx
@@ -35,12 +35,12 @@ const TreeControls = ({ hasNesting = true }) => {
 
   // Initialise sortBy from config on first render if it hasn't been set yet.
   useEffect(() => {
-    if (data.sortBy == null) {
+    if (data && data.sortBy == null) {
       updateState({ ...data, sortBy: config?.sortBy || "prefLabel" })
     }
-  }, [data.sortBy, config?.sortBy])
+  }, [data?.sortBy, config?.sortBy])
 
-  const currentSort = data.sortBy ?? config?.sortBy ?? "prefLabel"
+  const currentSort = data?.sortBy ?? config?.sortBy ?? "prefLabel"
 
   return (
     <div className="TreeControls" css={style}>
@@ -75,7 +75,10 @@ const TreeControls = ({ hasNesting = true }) => {
         <select
           aria-label="Sort entries by"
           value={currentSort}
-          onChange={(e) => updateState({ ...data, sortBy: e.target.value })}
+          onChange={(e) =>
+            updateState &&
+            updateState({ ...(data || {}), sortBy: e.target.value })
+          }
         >
           <option value="prefLabel">Label</option>
           <option value="notation">Notation</option>

--- a/src/components/nestedList.jsx
+++ b/src/components/nestedList.jsx
@@ -5,6 +5,7 @@ import { Link as GatsbyLink } from "gatsby"
 
 import { getConfigAndConceptSchemes } from "../hooks/configAndConceptSchemes"
 import { useSkoHubContext } from "../context/Context"
+import { sortConcepts } from "../sortConcepts"
 
 const getNestedItems = (item) => {
   let ids = [item.id]
@@ -151,7 +152,8 @@ const NestedList = ({
     }
   }
 
-  const filteredItems = getFilteredItems()
+  const sortBy = data?.sortBy ?? config?.sortBy ?? "prefLabel"
+  const filteredItems = sortConcepts(getFilteredItems(), sortBy, language)
   const t = i18n(language)
 
   const isExpanded = (item, truthy, falsy) => {

--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -5,6 +5,7 @@ const defaultState = {
   selectedLanguage: "",
   conceptSchemeLanguages: [],
   indexPage: false,
+  sortBy: null,
 }
 const Context = createContext(defaultState)
 

--- a/src/hooks/configAndConceptSchemes.js
+++ b/src/hooks/configAndConceptSchemes.js
@@ -85,6 +85,7 @@ export const getConfigAndConceptSchemes = () => {
           searchableAttributes
           customDomain
           failOnValidation
+          sortBy
         }
       }
       allConceptScheme {

--- a/src/sortConcepts.js
+++ b/src/sortConcepts.js
@@ -1,0 +1,47 @@
+const { i18n } = require("./common")
+
+/**
+ * Stable, locale-aware sort for SKOS-shaped items (concepts, collection
+ * members, top concepts).
+ *
+ * @param {Array} items
+ * @param {"prefLabel" | "notation" | "none" | null | undefined} sortBy
+ * @param {string} language - BCP-47 language tag used both to pick the
+ *   prefLabel string and as the locale for Intl.Collator
+ * @returns {Array} a new array (input is not mutated). When sortBy is "none"
+ *   or falsy, the original array is returned unchanged.
+ */
+const sortConcepts = (items, sortBy, language) => {
+  if (!Array.isArray(items) || items.length < 2) return items
+  if (!sortBy || sortBy === "none") return items
+
+  const t = i18n(language)
+  const collator = new Intl.Collator(language || undefined, {
+    numeric: true,
+    sensitivity: "base",
+  })
+
+  const labelOf = (item) => t(item.prefLabel) || item.id || ""
+  const notationOf = (item) =>
+    Array.isArray(item.notation) && item.notation.length > 0
+      ? String(item.notation[0])
+      : ""
+
+  const compareByLabel = (a, b) => collator.compare(labelOf(a), labelOf(b))
+
+  const compareByNotation = (a, b) => {
+    const na = notationOf(a)
+    const nb = notationOf(b)
+    if (na && nb) return collator.compare(na, nb)
+    // Items without a notation sink below items that have one; among the
+    // notation-less, fall back to prefLabel so the order is still meaningful.
+    if (na && !nb) return -1
+    if (!na && nb) return 1
+    return compareByLabel(a, b)
+  }
+
+  const compare = sortBy === "notation" ? compareByNotation : compareByLabel
+  return [...items].sort(compare)
+}
+
+module.exports = { sortConcepts }

--- a/src/templates/App.jsx
+++ b/src/templates/App.jsx
@@ -28,7 +28,7 @@ const App = ({ pageContext, children, location }) => {
   const [tree, setTree] = useState(
     pageContext.node.type === "ConceptScheme" ? pageContext.node : null
   )
-  let showTreeControls = false
+  let hasNesting = false
 
   const [labels, setLabels] = useState(
     Object.fromEntries(
@@ -41,14 +41,18 @@ const App = ({ pageContext, children, location }) => {
 
   handleKeypresses(labels, setLabels)
 
-  if (!showTreeControls && tree && tree.hasTopConcept) {
+  if (!hasNesting && tree && tree.hasTopConcept) {
     for (const topConcept of tree.hasTopConcept) {
       if (topConcept.narrower?.length > 0) {
-        showTreeControls = true
+        hasNesting = true
         break
       }
     }
   }
+  // Render controls (sort selector + optionally collapse/expand) whenever a
+  // tree of top concepts exists, so users can sort even flat schemes.
+  const showTreeControls =
+    tree && tree.hasTopConcept && tree.hasTopConcept.length > 0
 
   const [language, setLanguage] = useState("")
   const [currentScheme, setCurrentScheme] = useState(null)
@@ -177,7 +181,7 @@ const App = ({ pageContext, children, location }) => {
             labels={labels}
             onLabelClick={(e) => toggleClick(e)}
           />
-          {showTreeControls && <TreeControls />}
+          {showTreeControls && <TreeControls hasNesting={hasNesting} />}
           <div className="concepts">
             {tree && (
               <NestedList

--- a/test/collection.test.jsx
+++ b/test/collection.test.jsx
@@ -72,4 +72,58 @@ describe("Collection", () => {
       "/w3id.org/collection.json"
     )
   })
+
+  it("sorts collection members alphabetically by prefLabel by default", () => {
+    useSkoHubContext.mockReturnValue({
+      data: { selectedLanguage: "en", sortBy: "prefLabel" },
+      updateState: vi.fn(),
+    })
+    const unsortedCollection = {
+      node: {
+        id: "http://w3id.org/collection",
+        type: "Collection",
+        prefLabel: { en: "Unsorted" },
+        member: [
+          { id: "http://x/c", prefLabel: { en: "Charlie" } },
+          { id: "http://x/a", prefLabel: { en: "Alpha" } },
+          { id: "http://x/b", prefLabel: { en: "Bravo" } },
+        ],
+      },
+      language: "en",
+      customDomain: "",
+    }
+    renderCollection(history, unsortedCollection)
+    const links = screen
+      .getAllByRole("link")
+      .map((l) => l.textContent.trim())
+      .filter((t) => /^(Alpha|Bravo|Charlie)$/.test(t))
+    expect(links).toEqual(["Alpha", "Bravo", "Charlie"])
+  })
+
+  it("preserves source order when sortBy='none'", () => {
+    useSkoHubContext.mockReturnValue({
+      data: { selectedLanguage: "en", sortBy: "none" },
+      updateState: vi.fn(),
+    })
+    const unsortedCollection = {
+      node: {
+        id: "http://w3id.org/collection",
+        type: "Collection",
+        prefLabel: { en: "Unsorted" },
+        member: [
+          { id: "http://x/c", prefLabel: { en: "Charlie" } },
+          { id: "http://x/a", prefLabel: { en: "Alpha" } },
+          { id: "http://x/b", prefLabel: { en: "Bravo" } },
+        ],
+      },
+      language: "en",
+      customDomain: "",
+    }
+    renderCollection(history, unsortedCollection)
+    const links = screen
+      .getAllByRole("link")
+      .map((l) => l.textContent.trim())
+      .filter((t) => /^(Alpha|Bravo|Charlie)$/.test(t))
+    expect(links).toEqual(["Charlie", "Alpha", "Bravo"])
+  })
 })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -27,6 +27,7 @@ describe("Config Parsing", () => {
       },
       customDomain: "",
       failOnValidation: true,
+      sortBy: "prefLabel",
       fonts: {
         regular: {
           font_family: "Aladin",

--- a/test/mocks/mockConfig.js
+++ b/test/mocks/mockConfig.js
@@ -3,6 +3,7 @@ export const mockConfig = {
     siteMetadata: {
       searchableAttributes: ["prefLabel"],
       customDomain: "",
+      sortBy: "prefLabel",
       colors: {
         skoHubWhite: "rgb(255, 255, 255)",
         skoHubDarkColor: "rgb(15, 85, 75)",

--- a/test/nestedList.test.jsx
+++ b/test/nestedList.test.jsx
@@ -6,6 +6,8 @@ import { ConceptScheme, ConceptSchemeDeprecated } from "./data/pageContext"
 import userEvent from "@testing-library/user-event"
 import * as Gatsby from "gatsby"
 import { mockConfig } from "./mocks/mockConfig"
+import { ContextProvider, useSkoHubContext } from "../src/context/Context"
+import { useEffect } from "react"
 
 const useStaticQuery = vi.spyOn(Gatsby, `useStaticQuery`)
 
@@ -58,6 +60,71 @@ describe("Nested List", () => {
     expect(screen.getByRole("button", { expanded: true }))
     await user.click(screen.getByRole("button", { expanded: true }))
     expect(screen.getByRole("button", { expanded: false }))
+  })
+
+  describe("sorting", () => {
+    const unsorted = [
+      { id: "http://x/c", prefLabel: { en: "Charlie" }, notation: ["3"] },
+      { id: "http://x/a", prefLabel: { en: "Alpha" }, notation: ["1"] },
+      { id: "http://x/b", prefLabel: { en: "Bravo" }, notation: ["2"] },
+    ]
+
+    // Helper component that seeds context state for a test
+    const SetSort = ({ sortBy }) => {
+      const { data, updateState } = useSkoHubContext()
+      useEffect(() => {
+        updateState({ ...data, sortBy })
+      }, [sortBy])
+      return null
+    }
+
+    const renderWithSort = (sortBy) =>
+      render(
+        <ContextProvider>
+          <SetSort sortBy={sortBy} />
+          <NestedList
+            items={unsorted}
+            current={null}
+            queryFilter={null}
+            highlight={null}
+            language={"en"}
+          />
+        </ContextProvider>
+      )
+
+    it("sortBy='prefLabel' reorders entries alphabetically", () => {
+      renderWithSort("prefLabel")
+      const links = screen.getAllByRole("link")
+      const labels = links.map((l) => l.textContent.trim())
+      expect(labels).toEqual([
+        expect.stringMatching(/Alpha/),
+        expect.stringMatching(/Bravo/),
+        expect.stringMatching(/Charlie/),
+      ])
+    })
+
+    it("sortBy='notation' reorders by notation", () => {
+      renderWithSort("notation")
+      const links = screen.getAllByRole("link")
+      const labels = links.map((l) => l.textContent.trim())
+      // notations are 1 (Alpha), 2 (Bravo), 3 (Charlie)
+      expect(labels).toEqual([
+        expect.stringMatching(/Alpha/),
+        expect.stringMatching(/Bravo/),
+        expect.stringMatching(/Charlie/),
+      ])
+    })
+
+    it("sortBy='none' preserves source order", () => {
+      renderWithSort("none")
+      const links = screen.getAllByRole("link")
+      const labels = links.map((l) => l.textContent.trim())
+      expect(labels).toEqual([
+        expect.stringMatching(/Charlie/),
+        expect.stringMatching(/Alpha/),
+        expect.stringMatching(/Bravo/),
+      ])
+    })
   })
 
   it("shows deprecation notice for deprecated concepts", () => {

--- a/test/sortConcepts.test.js
+++ b/test/sortConcepts.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest"
+import { sortConcepts } from "../src/sortConcepts"
+
+const mk = (id, prefLabel, notation) => ({
+  id,
+  prefLabel,
+  ...(notation !== undefined ? { notation } : {}),
+})
+
+describe("sortConcepts", () => {
+  it("returns input unchanged when sortBy is 'none'", () => {
+    const items = [mk("c", { en: "Charlie" }), mk("a", { en: "Alpha" })]
+    expect(sortConcepts(items, "none", "en")).toBe(items)
+  })
+
+  it("returns input unchanged when sortBy is falsy", () => {
+    const items = [mk("c", { en: "Charlie" }), mk("a", { en: "Alpha" })]
+    expect(sortConcepts(items, null, "en")).toBe(items)
+    expect(sortConcepts(items, undefined, "en")).toBe(items)
+  })
+
+  it("does not mutate the input array", () => {
+    const items = [mk("c", { en: "Charlie" }), mk("a", { en: "Alpha" })]
+    const before = [...items]
+    sortConcepts(items, "prefLabel", "en")
+    expect(items).toEqual(before)
+  })
+
+  it("sorts alphabetically by prefLabel in the given language", () => {
+    const items = [
+      mk("c", { en: "Charlie" }),
+      mk("a", { en: "Alpha" }),
+      mk("b", { en: "Bravo" }),
+    ]
+    const sorted = sortConcepts(items, "prefLabel", "en")
+    expect(sorted.map((i) => i.id)).toEqual(["a", "b", "c"])
+  })
+
+  it("uses the selected language to choose the prefLabel string", () => {
+    const items = [
+      mk("x", { en: "Apple", de: "Zebra" }),
+      mk("y", { en: "Zebra", de: "Apfel" }),
+    ]
+    expect(sortConcepts(items, "prefLabel", "en").map((i) => i.id)).toEqual([
+      "x",
+      "y",
+    ])
+    expect(sortConcepts(items, "prefLabel", "de").map((i) => i.id)).toEqual([
+      "y",
+      "x",
+    ])
+  })
+
+  it("sorts notations numerically (1, 2, 10 — not 1, 10, 2)", () => {
+    const items = [
+      mk("a", { en: "A" }, ["10"]),
+      mk("b", { en: "B" }, ["2"]),
+      mk("c", { en: "C" }, ["1"]),
+    ]
+    const sorted = sortConcepts(items, "notation", "en")
+    expect(sorted.map((i) => i.id)).toEqual(["c", "b", "a"])
+  })
+
+  it("sorts notations lexically when they share a prefix (e.g. '1.10' after '1.2')", () => {
+    const items = [
+      mk("a", { en: "A" }, ["1.10"]),
+      mk("b", { en: "B" }, ["1.2"]),
+      mk("c", { en: "C" }, ["1.1"]),
+    ]
+    // numeric collation: 1.1 < 1.2 < 1.10
+    const sorted = sortConcepts(items, "notation", "en")
+    expect(sorted.map((i) => i.id)).toEqual(["c", "b", "a"])
+  })
+
+  it("places items without notation after notation-bearing items, tie-broken by prefLabel", () => {
+    const items = [
+      mk("z", { en: "Zeta" }), // no notation
+      mk("a", { en: "Alpha" }, ["5"]),
+      mk("m", { en: "Mu" }), // no notation
+    ]
+    const sorted = sortConcepts(items, "notation", "en")
+    expect(sorted.map((i) => i.id)).toEqual(["a", "m", "z"])
+  })
+
+  it("falls back to id when prefLabel is missing for the requested language", () => {
+    const items = [mk("zzz", { de: "ignored" }), mk("aaa", { de: "ignored" })]
+    const sorted = sortConcepts(items, "prefLabel", "en")
+    expect(sorted.map((i) => i.id)).toEqual(["aaa", "zzz"])
+  })
+
+  it("returns input unchanged when fewer than two items", () => {
+    expect(sortConcepts([], "prefLabel", "en")).toEqual([])
+    const single = [mk("a", { en: "A" })]
+    expect(sortConcepts(single, "prefLabel", "en")).toBe(single)
+  })
+
+  it("handles non-array input gracefully", () => {
+    expect(sortConcepts(null, "prefLabel", "en")).toBe(null)
+    expect(sortConcepts(undefined, "prefLabel", "en")).toBe(undefined)
+  })
+})

--- a/test/treeControls.test.jsx
+++ b/test/treeControls.test.jsx
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import React from "react"
+import * as Gatsby from "gatsby"
 import TreeControls from "../src/components/TreeControls"
 import userEvent from "@testing-library/user-event"
+import { ContextProvider } from "../src/context/Context"
+import { mockConfig } from "./mocks/mockConfig"
+
+const useStaticQuery = vi.spyOn(Gatsby, `useStaticQuery`)
 
 const doc = (
-  <div>
+  <ContextProvider>
     <TreeControls />
     <ul>
       <li>
@@ -31,10 +36,14 @@ const doc = (
         </div>
       </li>
     </ul>
-  </div>
+  </ContextProvider>
 )
 
 describe("TreeControls", () => {
+  beforeEach(() => {
+    useStaticQuery.mockImplementation(() => mockConfig)
+  })
+
   it("tree controls expands and collapse buttons are setting attributes", async () => {
     const user = userEvent.setup()
     render(doc)
@@ -44,5 +53,42 @@ describe("TreeControls", () => {
 
     await user.click(screen.getByRole("button", { name: /collapse/i }))
     expect(screen.getByRole("button", { expanded: false }))
+  })
+
+  it("renders sort selector with config default selected", () => {
+    render(doc)
+    const select = screen.getByRole("combobox", { name: /sort entries by/i })
+    expect(select).toHaveValue("prefLabel")
+    expect(screen.getByRole("option", { name: "Label" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Notation" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("option", { name: "Source order" })
+    ).toBeInTheDocument()
+  })
+
+  it("changing sort selector updates the value", async () => {
+    const user = userEvent.setup()
+    render(doc)
+    const select = screen.getByRole("combobox", { name: /sort entries by/i })
+    await user.selectOptions(select, "notation")
+    expect(select).toHaveValue("notation")
+  })
+
+  it("hides Collapse/Expand buttons when hasNesting is false", () => {
+    render(
+      <ContextProvider>
+        <TreeControls hasNesting={false} />
+      </ContextProvider>
+    )
+    expect(
+      screen.queryByRole("button", { name: /expand/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /collapse/i })
+    ).not.toBeInTheDocument()
+    // Sort selector still visible
+    expect(
+      screen.getByRole("combobox", { name: /sort entries by/i })
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- Closes #336. Concepts in ConceptScheme trees and members of `skos:Collection` are now sorted at display time. Default: alphabetical by `skos:prefLabel`.
- New config option `sortBy: "prefLabel" | "notation" | "none"` in `config.default.yaml` seeds the initial order.
- New **Sort** selector in `TreeControls` lets visitors switch order at runtime (Label / Notation / Source order).
- Sorting uses `Intl.Collator` with `numeric: true`, so notations like `1, 2, 10` and `1.1, 1.2, 1.10` order naturally. Items without a notation fall to the bottom when sorting by notation, tie-broken by `prefLabel`.
- `TreeControls` now renders for flat (non-hierarchical) schemes too, so the sort selector is always reachable. Collapse/Expand stay hidden when there is no nesting.

### Behavior change to be aware of
Existing sites rebuilt on this version will display tree entries alphabetically by default. Maintainers who want to preserve TTL source order should set `sortBy: "none"` in their `config.yaml`.