### PR TITLE
Make skohub-vocabs-docker runnable as an arbitrary uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,17 @@ RUN npm i --only=production
 # disable notifier warning
 RUN npm config set update-notifier false
 
+# Make the image runnable as an arbitrary uid (e.g. `docker run --user <uid>:<gid>`),
+# so a webhook host process can own the build output it bind-mounts and clean it up
+# on rebuild. Without this the image only works as its baked-in `node` user:
+#  - HOME/npm cache point at a writable, uid-independent location
+#  - /app and the gatsby build cache are writable by any uid
+#  - gatsby writes latest-adapters.js into its own package dir at build time,
+#    so that dir must be writable by an arbitrary uid too
+ENV HOME=/tmp
+ENV NPM_CONFIG_CACHE=/tmp/.npm
+RUN mkdir -p /app/.cache \
+ && chmod -R a+rwX /app/.cache /app/node_modules/gatsby \
+ && chmod a+rwX /app
+
 CMD ["npm", "run", "container-build"]


### PR DESCRIPTION
Closes #347

## Summary

Makes the `skohub/skohub-vocabs-docker` image runnable as an arbitrary uid (`docker run --user <uid>:<gid>`), not only as its baked-in `node` user.

- Relocate `HOME` and the npm cache to `/tmp` (`ENV HOME=/tmp`, `ENV NPM_CONFIG_CACHE=/tmp/.npm`) so they're writable by any uid.
- Make `/app`, `/app/.cache`, and `/app/node_modules/gatsby` world-writable. Gatsby (on the node-22 base) writes `latest-adapters.js` into its own package dir at build time, so that path must be writable too. Scoped to the gatsby package dir (~20M) rather than all of `node_modules` (~593M) to minimise image bloat.

The default `node` user is unaffected — the relevant paths simply become more permissive.

## Why

This unblocks the host/systemd deployment of skohub-webhook (skohub-io/skohub-webhook#34, skohub-io/skohub-webhook#36). There the webhook runs as a non-root service user and runs the build container with `--user $(id -u):$(id -g)` so the bind-mounted build output is owned by the service user and can be cleaned up on the next rebuild (otherwise `EACCES`). That only works if the image tolerates an arbitrary uid.

## Test plan

Built from this branch on the node-22 base and validated locally:

- [x] `docker run --user 1001:1001 …` → build RC=0, no `EACCES`, output in `public/` owned by uid 1001 (incl. subdirs)
- [x] Default `node` user → build RC=0, no `EACCES`
- [x] Rebuild/cleanup cycle: build → move output → a uid-1001 process removes the container-created output → all RC=0 (the original rebuild `EACCES` is gone)

Note: the `docker` CI job (default-user image run + `:dev` publish) is gated to `dev`/`main`, so it does not run on this feature branch — it runs on merge to `dev`. The `build` and `e2e` jobs run here.

## Deploy ordering

This is the **first** step of a two-repo change. The patched image must be published **before** a webhook with `--user` is deployed (running the stock image as a foreign uid fails the build). Merging here publishes the `:dev` tag; the companion webhook change (skohub-io/skohub-webhook#35) must not deploy against `:latest` until this reaches `main`.